### PR TITLE
Update-8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The file verification is made with SHA256.
 
 ## Getting Started
 
-Install NodeJS: https://nodejs.org/en/download/ \
+Install NodeJS (16 or better): https://nodejs.org/en/download/ \
 Install Yarn: https://yarnpkg.com/getting-started/install
 
 Clone the repository:

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,39 @@
 export const patchlistUrl = 'https://url/files.json'
 export const patchlistFolder = 'https://url/files/'
 
-export const enableDiscordButton = true
+/*
+Karbust Localhost Debug URLs:
+
+export const patchlistUrl = 'http://localhost:81/electron/files.json'
+export const patchlistFolder = 'http://localhost:81/electron/files/'
+ */
+
+export const enableDiscordButton = true //if false the button will not be displayed.
 export const discordUrl = 'https://discord.gg/invite'
 
 export const serverName = 'Karbust'
 export const binaryName = 'Metin2Debug.exe'
 export const configName = 'config.exe'
 export const launchParameters = ['--something']
+
+export const enableLocaleCfgUpdate = false //if true the locale.cfg will be updated when changing the language.
+export const localeCfgPath = 'locale.cfg' //default place, if it's inside a folder, prepend the path of such folder.
+/*
+Example:
+export const localeCfgPath = 'settings\\locale.cfg'
+
+Don't put the backslashes in the beginning, and in the middle use 2.
+ */
+export const locales: Record<string, string> = {
+    'de': '10002 1252 de',
+    'es': '10002 1252 es',
+    'en': '10002 1252 en',
+    'fr': '10002 1252 fr',
+    'pl': '10002 1250 pl',
+    'pt': '10000 1252 pt',
+    'ro': '10002 1250 ro',
+    'tr': '10012 1254 tr'
+}
 
 /* NOT BEING USED
 export const ServerUrl = 'https://karbust.me/'


### PR DESCRIPTION
Added support for update `locale.cfg` when changing the language on the patcher. The default value is `false` which means the `locale.cfg` file will not be updated when changing the patcher's language.
To set it up edit `src\config.ts`.